### PR TITLE
Calculate and Upload Cal Data

### DIFF
--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -117,6 +117,48 @@ module.exports = () => {
           console.log('uploaded to xDripAPS, statusCode = ' + response.statusCode);
         }
       })
+    },
+
+    postCalibration: (calData) => {
+
+      const entry = [{
+        'device': 'openaps://' + os.hostname(),
+        'type': 'cal',
+        'date': calData.date,
+        'scale': calData.scale,
+        'intercept': calData.intercept,
+        'slope': calData.slope,
+      }];
+
+      const data = JSON.stringify(entry);
+
+      const secret = process.env.API_SECRET;
+      let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/entries.json';
+      let ns_headers = {
+          'Content-Type': 'application/json'
+      };
+
+      if (secret.startsWith("token=")) {
+        ns_url = ns_url + '?' + secret;
+      } else {
+        ns_headers['API-SECRET'] = secret;
+      }
+
+      const optionsNS = {
+          url: ns_url,
+          method: 'POST',
+          headers: ns_headers,
+          body: entry,
+          json: true
+      };
+
+      request(optionsNS, function (error, response, body) {
+        if (error) {
+          console.error('error posting json: ', error)
+        } else {
+          console.log('uploaded new calibration to NS, statusCode = ' + response.statusCode);
+        }
+      })
     }
   };
 };


### PR DESCRIPTION
This is a work in progress. The goal is to allow Lookout to continue reporting glucose values after a sensor expires to provide more flexibility on when the sensor is changed.

It will do this by maintaining a running calibration slope and intercept calculated from the calibrated and unfiltered glucose values reported by the transmitter. If the glucose value calculated from the current slope and intercept differ from the G5 calibrated value by more than 10 points, the slope and intercept are recalculated.

When the G5 reports a null calibrated value, Lookout will calculate a glucose value using the most recent calibration terms and the unfiltered value. Once calibrated values return, it will revert back to the G5 calibrated values and resume maintaining a running slope and intercept based on the G5 calibrated values.

A side benefit is the calibration terms can be uploaded to NS so NS can display raw values.