### PR TITLE
Upload Cal Data to NS and Extend Sensor Life Option

### DIFF
--- a/calibration.js
+++ b/calibration.js
@@ -78,8 +78,7 @@ exports.lsrCalibration = (calibrationPairs) => {
 
   var denominator=Math.sqrt(((n * sumXSq - sumX*sumX) * (n * sumYSq - sumY*sumY)));
   if ((denominator == 0) || (stddevX == 0)) {
-    returnVal.slope=1000;
-    returnVal.yIntercept=0;
+    return null;
   } else {
     let r=(n * sumXY - sumX * sumY) / denominator;
 
@@ -99,6 +98,8 @@ exports.lsrCalibration = (calibrationPairs) => {
     yError=Math.sqrt(vari / delta * sumXSq);
     slopeError=Math.sqrt(n / delta * vari);
   }
+
+  console.log('lsrCalibration: numPoints=' + n + ', slope=' + returnVal.slope + ', yIntercept=0'); 
 
   return returnVal;
 };

--- a/calibration.js
+++ b/calibration.js
@@ -1,5 +1,21 @@
 var _ = require('lodash');
 
+//Rule 1 - Clear calibration records upon CGM Sensor Change/Insert
+//Rule 2 - Don't allow any BG calibrations or take in any new calibrations 
+//         within 15 minutes of last sensor insert
+//Rule 3 - Only use Single Point Calibration for 1st 12 hours since Sensor insert
+//Rule 4 - Do not store calibration records within 12 hours since Sensor insert. 
+//         Use for SinglePoint calibration, but then discard them
+//Rule 5 - Do not use LSR until we have 4 or more calibration points. 
+//         Use SinglePoint calibration only for less than 4 calibration points. 
+//         SinglePoint simply uses the latest calibration record and assumes 
+//         the yIntercept is 0.
+//Rule 6 - Drop back to SinglePoint calibration if slope is out of bounds 
+//         (>MAXSLOPE or <MINSLOPE)
+//Rule 7 - Drop back to SinglePoint calibration if yIntercept is out of bounds 
+//        (> minimum unfiltered value in calibration record set or 
+//         < - minimum unfiltered value in calibration record set)
+
 var exports = module.exports = {};
 
 // calibrationPairs has three values for each array element:

--- a/calibration.js
+++ b/calibration.js
@@ -115,7 +115,7 @@ exports.lsrCalibration = (calibrationPairs) => {
     slopeError=Math.sqrt(n / delta * vari);
   }
 
-  console.log('lsrCalibration: numPoints=' + n + ', slope=' + returnVal.slope + ', yIntercept=0'); 
+  console.log('lsrCalibration: numPoints=' + n + ', slope=' + returnVal.slope + ', yIntercept=' + returnVal.yIntercept); 
 
   return returnVal;
 };

--- a/calibration.js
+++ b/calibration.js
@@ -1,0 +1,121 @@
+var _ = require('lodash');
+
+var exports = module.exports = {};
+
+// calibrationPairs has three values for each array element:
+//   glucose => the "true" glucose value for the pair
+//   unfiltered => the sensor's unfiltered glucose value for the pair
+//   readDate => the sensor's read date for the pair in ms since 1/1/1970 00:00
+exports.lsrCalibration = (calibrationPairs) => {
+  var sumX=0;
+  var sumY=0;
+  var meanX=0;
+  var meanY=0;
+  var stddevX=0;
+  var stddevY=0;
+  var sumXY=0;
+  var sumXSq=0;
+  var sumYSq=0;
+  var r=0;
+  var n=calibrationPairs.length
+  var tarr = [];
+
+  var returnVal = {
+    'slope': 0,
+    'yIntercept': 0,
+    'calibrationType': 'LeastSquaresRegression'
+  };
+
+  for (let i=0; i < n; ++i) {
+    sumX = sumX + calibrationPairs[i].glucose;
+    sumY = sumY + calibrationPairs[i].unfiltered;
+  }
+
+  meanX = sumX / n;
+  meanY = sumY / n;
+
+  sumSqDiffX = 0;
+  sumSqDiffY = 0;
+
+  for (let i=0; i < n; ++i) {
+    let diff = calibrationPairs[i].glucose - meanX;
+    sumSqDiffX = sumSqDiffX + diff*diff;
+
+    diff = calibrationPairs[i].unfiltered - meanY;
+    sumSqDiffY = sumSqDiffY + diff*diff;
+  }
+
+  stddevX = Math.sqrt(sumSqDiffX / (n-1));
+  stddevY = Math.sqrt(sumSqDiffY / (n-1));
+
+
+  var usingDates=0
+
+  var firstDate=calibrationPairs[0].readDate;
+
+  for (let i=0; i<n; i++) {
+      tarr.push(calibrationPairs[i].readDate - firstDate); 
+  }
+
+  var multiplier=1
+
+  for (let i=0; i<n; i++ ) {
+    if (i != 0) {
+      multiplier=1 + tarr[i-1] / (tarr[n-1] * 2);
+
+      // boundary check
+      if ((multiplier < 1) || (multiplier > 2)) {
+        multiplier=1;
+      }
+    }
+
+    console.log('Calibration - record ' + i + ', ' + new Date(calibrationPairs[i].readDate) + ', weighted multiplier=' + multiplier);
+ 
+    sumXY=(sumXY + calibrationPairs[i].glucose * calibrationPairs[i].unfiltered) * multiplier;
+    sumXSq=(sumXSq + calibrationPairs[i].glucose * calibrationPairs[i].glucose) * multiplier;
+    sumYSq=(sumYSq + calibrationPairs[i].unfiltered * calibrationPairs[i].unfiltered) * multiplier;
+  }
+
+  var denominator=Math.sqrt(((n * sumXSq - sumX*sumX) * (n * sumYSq - sumY*sumY)));
+  if ((denominator == 0) || (stddevX == 0)) {
+    returnVal.slope=1000;
+    returnVal.yIntercept=0;
+  } else {
+    let r=(n * sumXY - sumX * sumY) / denominator;
+
+    returnVal.slope=r * stddevY / stddevX;
+    returnVal.yIntercept=meanY - returnVal.slope * meanX;
+
+    // calculate error
+    let varSum=0;
+    for (let j=0; j<n; j++) {
+      let varVal = (calibrationPairs[j].unfiltered - returnVal.yIntercept - returnVal.slope * calibrationPairs[j].glucose);
+      varSum=varSum + varVal * varVal;
+    }
+
+    let delta=n * sumXSq - sumX*sumX;
+    let vari=1.0 / (n - 2.0) * varSum;
+  
+    yError=Math.sqrt(vari / delta * sumXSq);
+    slopeError=Math.sqrt(n / delta * vari);
+  }
+
+  return returnVal;
+};
+
+exports.singlePointCalibration = (calibrationPairs) => {
+  var returnVal = {
+    'slope': 0,
+    'yIntercept': 0,
+    'calibrationType': 'SinglePoint'
+  };
+
+  x=calibrationPairs[calibrationPairs.length-1].glucose;
+  y=calibrationPairs[calibrationPairs.length-1].unfiltered;
+  returnVal.yIntercept=0;
+  returnVal.slope=y / x;
+  console.log('singlePointCalibration: x=' + x + ', y=' + y + ', slope=' + returnVal.slope + ', yIntercept=0'); 
+
+  return returnVal;
+};
+

--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ io.on('connection', (socket) => {
 const argv = require('yargs').argv;
 const TransmitterIO = argv.sim ? require('./transmitterIO-simulated') : require('./transmitterIO')
 
-TransmitterIO(io.of('/cgm'));
+TransmitterIO(io.of('/cgm'), argv.extend_sensor);
 LoopIO(io.of('/loop'));
 PumpIO(io.of('/pump'));

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chart.js": "^2.7.1",
     "chokidar": "^1.7.0",
     "express": "^4.15.2",
+    "lodash": "^4.15.0",
     "mobile-angular-ui": "^1.3.4",
     "moment": "^2.19.2",
     "ngstorage": "^0.3.11",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ngstorage": "^0.3.11",
     "node-persist": "^2.1.0",
     "request": "^2.83.0",
+    "request-promise-native": "^1.0.5",
     "socket.io": "^1.7.3",
     "xdrip-js": "thebookins/xdrip-js#dev",
     "yargs": "^10.0.3"

--- a/transmitterIO-simulated.js
+++ b/transmitterIO-simulated.js
@@ -1,7 +1,7 @@
 const xDripAPS = require("./xDripAPS")();
 const Transmitter = require('xdrip-js');
 
-module.exports = (io) => {
+module.exports = (io, extend_sensor) => {
   let id = 'ABCDEF';
   const version = '1.2.3.4';
   const glucose = {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -123,13 +123,6 @@ module.exports = (io, extend_sensor_opt) => {
     .then(() => {
       return storage.getItem('glucose');
     })
-    .catch(() => {
-      lastCal = null;
-      console.log('Unable to obtain current NS Calibration');
-    })
-    .then(() => {
-      return storage.getItem('glucose');
-    })
     .then(lastSGV => {
       var newCal = calculateNewNSCalibration(lastCal, lastSGV, sgv);
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -220,7 +220,7 @@ module.exports = (io, extend_sensor_opt) => {
 
   const processNewGlucose = (sgv) => {
     let lastCal = null;
-    let glucoseHist = null;
+    let glucoseHist = [];
     let checkingSensorInsert = false;
     let sendSGV = true;
 
@@ -239,13 +239,17 @@ module.exports = (io, extend_sensor_opt) => {
       glucoseHist = storedGlucoseHist;
     })
     .catch((err) => {
-      glucoseHist = null;
+      glucoseHist = [];
       console.log('Error getting glucoseHist: ' + err);
     })
     .then(() => {
       let newCal = null;
 
-      if (glucoseHist && (glucoseHist.length > 0)) {
+      if (!glucoseHist) {
+        glucoseHist = [];
+      }
+
+      if (glucoseHist.length > 0) {
         newCal = calculateNewNSCalibration(lastCal, glucoseHist[glucoseHist.length - 1], sgv);
       }
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -266,7 +266,7 @@ module.exports = (io, extend_sensor_opt) => {
       }
 
       if (glucoseHist.length > 0) {
-        newCal = calculateNewNSCalibration(lastCal, glucoseHist[glucoseHist.length - 1], sgv);
+        newCal = calculateNewNSCalibration(lastCal, glucoseHist[0], sgv);
       }
 
       if (newCal) {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -54,7 +54,7 @@ module.exports = (io, extend_sensor_opt) => {
         var slope =  (lastSGV.unfiltered - currSGV.unfiltered) / (lastSGV.glucose - currSGV.glucose);
         var intercept = currSGV.unfiltered - currSGV.glucose*slope;
 
-        if ((slope > 12.5) || (slope < 0.75)) {
+        if ((slope > 12.5) || (slope < 0.45)) {
           // wait until the next opportunity
           console.log('Slope out of range to calibrate: ' + slope);
           return null;

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -144,9 +144,9 @@ module.exports = (io, extend_sensor_opt) => {
     let firstTime = moment(yarr[0].date);
 
     let lastSGV = yarr[n-1].glucose;
-    let lastSGV = moment(yarr[n-1].date);
+    let lastTime = moment(yarr[n-1].date);
 
-    var overallsod=Math.sqrt(Math.pow(lastSGV - firstSGV, 2) + Math.pow(lastSGV.diff(firstSGV,'seconds')*30, 2));
+    var overallsod=Math.sqrt(Math.pow(lastSGV - firstSGV, 2) + Math.pow(lastTime.diff(firstTime,'seconds')*30, 2));
 
     if (sod == 0) {
       // assume no noise if no records

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -113,9 +113,9 @@ module.exports = (io, extend_sensor_opt) => {
     const MAXRECORDS=8;
     const MINRECORDS=4;
 
-    var yarg = glucoseHist.slice(-MAXRECORDS);
+    var yarr = glucoseHist.slice(-MAXRECORDS);
 
-    n=yarg.length;
+    n=yarr.length;
 
     // sod = sum of distances
     var sod=0;

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -174,7 +174,7 @@ module.exports = (io, extend_sensor_opt) => {
       let timeSpan = 0;
 
       // delete any deltas > 15 minutes
-      for (var i=0; i < glucoseHist.length); ++i) {
+      for (var i=0; i < glucoseHist.length; ++i) {
         if (moment(glucoseHist[i].date).diff(minDate) < 0) {
           sliceStart = i+1;
         }

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -113,7 +113,7 @@ module.exports = (io, extend_sensor_opt) => {
     const MAXRECORDS=8;
     const MINRECORDS=4;
 
-    var yarg = glucostHist.slice(-MAXRECORDS);
+    var yarg = glucoseHist.slice(-MAXRECORDS);
 
     n=yarg.length;
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -224,7 +224,7 @@ module.exports = (io, extend_sensor_opt) => {
     let deltaSGV = 0;
 
     if (glucoseHist.length > 1) {
-      deltaSGV = currSGV.glucose - glucoseHist[glucoseHist.length-2];
+      deltaSGV = currSGV.glucose - glucoseHist[glucoseHist.length-2].glucose;
     }
 
     if (currSGV.glucose > 400) {
@@ -407,6 +407,7 @@ module.exports = (io, extend_sensor_opt) => {
         io.emit('pending', pending);
       } else if (m.msg == "calibrationData") {
         // TODO: save to node-persist?
+        console.log('Last calibration: ' + (Date.now() - m.data.date)/1000/60 + ' minutes ago');
         storage.setItem('calibration', m.data)
         .then(() => {
           io.emit('calibrationData', m.data);

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -162,7 +162,7 @@ module.exports = (io, extend_sensor_opt) => {
   // Also added weight for points where the delta shifts from pos to neg or neg to pos (peaks/valleys)
   // the more peaks and valleys, the more noise is amplified
   const calcSensorNoise = (glucoseHist) => {
-    const MAXRECORDS=12;
+    const MAXRECORDS=8;
     const MINRECORDS=4;
     var noise = 0;
 
@@ -277,13 +277,13 @@ module.exports = (io, extend_sensor_opt) => {
       nsNoise = 2;
     } else if (Math.abs(deltaSGV) > 30) {
       console.log('Glucose change ' + deltaSGV + ' out of range [-30, 30] - setting noise level Heavy');
-    } else if (noise < 0.3) {
+    } else if (noise < 0.35) {
       nsNoise = 1; // Clean
-    } else if (noise < 0.45) {
+    } else if (noise < 0.5) {
       nsNoise = 2; // Light
-    } else if (noise < 0.6) {
+    } else if (noise < 0.7) {
       nsNoise = 3; // Medium
-    } else if (noise >= 0.6) {
+    } else if (noise >= 0.7) {
       nsNoise = 4; // Heavy
     }
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -235,9 +235,9 @@ module.exports = (io, extend_sensor_opt) => {
       nsNoise = 2;
     } else if (Math.abs(deltaSGV) > 30) {
       console.log('Glucose change ' + deltaSGV + ' out of range [-30, 30] - setting noise level Heavy');
-    } else if (noise < 0.2) {
+    } else if (noise < 0.3) {
       nsNoise = 1; // Clean
-    } else if (noise < 0.4) {
+    } else if (noise < 0.45) {
       nsNoise = 2; // Light
     } else if (noise < 0.6) {
       nsNoise = 3; // Medium

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -39,9 +39,7 @@ module.exports = (io, extend_sensor_opt) => {
 
     var calErr = 100;
     var calValue;
-    var sliceStart = 0;
     var i;
-    var priorSGV = null;
 
     var calPairs = [];
     // Suitable values need to be:

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -44,8 +44,11 @@ module.exports = (io, extend_sensor_opt) => {
 
 
     // Remove glucose readings prior to the last G5 calibration event
+    // add 12 minutes to the calibration event because it sometimes
+    // takes up to 2 readings after the calibration for the
+    // calibration to be reflected in the transmitter's calibrated SGV
     for (i=0; i < glucoseHist.length; ++i) {
-        if (glucoseHist[i].readDate < lastG5CalTime) {
+        if (glucoseHist[i].readDate < (lastG5CalTime + 12*60*1000)) {
           sliceStart = i+1;
         }
     }
@@ -457,7 +460,7 @@ module.exports = (io, extend_sensor_opt) => {
         io.emit('pending', pending);
       } else if (m.msg == "calibrationData") {
         // TODO: save to node-persist?
-        console.log('Last calibration: ' + (Date.now() - m.data.date)/1000/60 + ' minutes ago');
+        console.log('Last calibration: ' + Math.round((Date.now() - m.data.date)/1000/60/60*10)/10 + ' hours ago');
         storage.setItem('calibration', m.data)
         .then(() => {
           io.emit('calibrationData', m.data);

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -126,10 +126,10 @@ module.exports = (io, extend_sensor_opt) => {
 
     n=sgvArr.length;
 
-    let firstSGV = sgvArr[0].glucose;
+    let firstSGV = sgvArr[0].glucose * 1000.0;
     let firstTime = sgvArr[0].readDate / 1000.0 * 30.0;
 
-    let lastSGV = sgvArr[n-1].glucose;
+    let lastSGV = sgvArr[n-1].glucose * 1000.0;
     let lastTime = sgvArr[n-1].readDate / 1000.0 * 30.0;
 
     let xarr = [];
@@ -145,7 +145,7 @@ module.exports = (io, extend_sensor_opt) => {
     for (var i=1; i < n; i++) {
       // y2y1Delta adds a multiplier that gives 
       // higher priority to the latest BG's
-      let y2y1Delta=(sgvArr[i].glucose - sgvArr[i-1].glucose) * (1 + i / (n*3));
+      let y2y1Delta=(sgvArr[i].glucose - sgvArr[i-1].glucose) * 1000.0 * (1 + i / (n*3));
 
       let x2x1Delta=xarr[i] - xarr[i-1];
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -67,7 +67,7 @@ module.exports = (io, extend_sensor_opt) => {
       }
     }
 
-    priorSGV = sgvHist[maxDeltaIndex].glucose;
+    priorSGV = sgvHist[maxDeltaIndex];
 
     if (lastCal) {
       calValue = (currSGV.unfiltered-lastCal.intercept)/lastCal.slope;

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -44,7 +44,7 @@ module.exports = (io, extend_sensor_opt) => {
 
 
     // Remove glucose readings prior to the last G5 calibration event
-    for (i=0; glucoseHist[i].readDate; ++i) {
+    for (i=0; i < glucoseHist.length; ++i) {
         if (glucoseHist[i].readDate < lastG5CalTime) {
           sliceStart = i+1;
         }
@@ -100,9 +100,9 @@ module.exports = (io, extend_sensor_opt) => {
           slope: slope
         };
       } else {
-        console.log('Calibration needed, but not enough separation between last and current values.');
-        console.log('Last unfiltered: ' + priorSGV.unfiltered + ' Current unfiltered: ' + currSGV.unfiltered);
-        console.log('Last SGV: ' + priorSGV.glucose + ' Current SGV: ' + currSGV.glucose);
+        console.log('Calibration needed, but not enough separation between relavent historical values and current value.');
+        console.log('Unfiltered with greatest distance: ' + priorSGV.unfiltered + ' Current unfiltered: ' + currSGV.unfiltered);
+        console.log('SGV with greatest distance: ' + priorSGV.glucose + ' Current SGV: ' + currSGV.glucose);
         return null;
       }
     } else {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -128,7 +128,7 @@ module.exports = (io, extend_sensor_opt) => {
       // higher priority to the latest BG's
       let x2x1Delta=moment(yarr[i].date).diff(moment(yarr[i-1].date), 'seconds')*30;
 
-      if ((lastDelta > 0 && (y2y1Delta < 0)) {
+      if ((lastDelta > 0) && (y2y1Delta < 0)) {
         // switched from positive delta to negative, increase noise impact  
         y2y1Delta=y2y1Delta * 1.1;
       }

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -307,6 +307,7 @@ module.exports = (io, extend_sensor_opt) => {
     })
     .then(() => {
         return storage.getItem('calibration');
+    })
     .catch((err) => {
       console.log('Error getting lastG5CalData: ' + err);
     })

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -110,8 +110,8 @@ module.exports = (io, extend_sensor_opt) => {
   }
 
   const calcSensorNoise = (glucoseHist) => {
-    const let MAXRECORDS=8;
-    const let MINRECORDS=4;
+    const MAXRECORDS=8;
+    const MINRECORDS=4;
 
     var yarg = glucostHist.slice(-MAXRECORDS);
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -304,6 +304,8 @@ module.exports = (io, extend_sensor_opt) => {
 
       sgv.noise = calcSensorNoise(glucoseHist);
 
+      console.log('Current sensor trend: ' + sgv.trend + ' Sensor Noise: ' + sgv.noise);
+
       sgv.nsNoise = calcNSNoise(sgv.noise);
 
       console.log('Current sensor noise: ' + sgv.noise + ' NS Noise: ' + sgv.nsNoise);

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -323,7 +323,7 @@ module.exports = (io, extend_sensor_opt) => {
       // only the store the last hour of glucose
       // the primary use is to determine the
       // trend and the noise values
-      for (var i=0; i < glucoseHist.length); ++i) {
+      for (var i=0; i < glucoseHist.length; ++i) {
         if (moment(glucoseHist[i].date).diff(minDate) < 0) {
           sliceStart = i+1;
         }

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -92,7 +92,7 @@ module.exports = (io, extend_sensor_opt) => {
           date: Date.now(),
           scale: 1,
           intercept: calResult.yIntercept,
-          slope: calResult.slope
+          slope: calResult.slope,
           type: calResult.calibrationType
         };
       } else {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -134,7 +134,7 @@ module.exports = (io, extend_sensor_opt) => {
       }
       else if ((lastDelta < 0) && (y2y1Delta > 0)) {
         // switched from negative delta to positive, increase noise impact 
-        y2y1Delta=y2y1Delta} * 1.2;
+        y2y1Delta=y2y1Delta * 1.2;
       }
 
       sod=sod + Math.sqrt(Math.pow(x2x1Delta, 2) + Math.pow(y2y1Delta, 2));

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -1,5 +1,5 @@
 const xDripAPS = require("./xDripAPS")();
-const calibration = require("./calibration")();
+const calibration = require('./calibration');
 const storage = require('node-persist');
 const cp = require('child_process');
 const request = require('request-promise-native');

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -276,31 +276,6 @@ module.exports = (io, extend_sensor_opt) => {
     return nsNoise;
   }
 
-  const stateString = (state) => {
-    switch (state) {
-      case 0x01:
-        return "Stopped";
-      case 0x02:
-        return "Warmup";
-      case 0x04:
-        return "First calibration";
-      case 0x05:
-        return "Second calibration";
-      case 0x06:
-        return "OK";
-      case 0x07:
-        return "Need calibration";
-      case 0x0a:
-        return "Enter new BG meter value";
-      case 0x0b:
-        return "Failed sensor";
-      case 0x12:
-        return "???";
-      default:
-        return state ? "Unknown: 0x" + state.toString(16) : '--';
-    }
-  }
-
   const processNewGlucose = (sgv) => {
     let lastCal = null;
     let glucoseHist = [];
@@ -444,7 +419,6 @@ module.exports = (io, extend_sensor_opt) => {
   }
 
   const sendNewGlucose = (sgv) => {
-    console.log('Sensor State: ' + stateString(sgv.state));
     io.emit('glucose', sgv);
     xDripAPS.post(sgv);
   }

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -29,7 +29,7 @@ module.exports = () => {
         direction = 'DoubleUp';
       }
 
-      console.log('Trend: ' + glucose.trend + ' direction: ' + direction);
+      console.log('Trend: ' + Math.round(glucose.trend*10)/10 + ' direction: ' + direction);
 
       const entry = [{
         'device': 'openaps://' + os.hostname(),

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -127,6 +127,7 @@ module.exports = () => {
         'device': 'openaps://' + os.hostname(),
         'type': 'cal',
         'date': calData.date,
+        'dateString': new Date(calData.date).toISOString(),
         'scale': calData.scale,
         'intercept': calData.intercept,
         'slope': calData.slope,

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -16,7 +16,7 @@ module.exports = () => {
       if (glucose.trend <= -30) {
         direction = 'DoubleDown';
       } else if (glucose.trend <= -20) {
-        direction = 'SingeDown';
+        direction = 'SingleDown';
       } else if (glucose.trend <= -10) {
         direction = 'FortyFiveDown';
       } else if (glucose.trend < 10) {
@@ -39,7 +39,7 @@ module.exports = () => {
         'filtered': glucose.filtered,
         'unfiltered': glucose.unfiltered,
         'rssi': "100", // TODO: consider reading this on connection and reporting
-        'noise': "1",
+        'noise': glucose.nsNoise,
         'trend': glucose.trend,
         'glucose': glucose.glucose
       }];

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -117,6 +117,48 @@ module.exports = () => {
           console.log('uploaded to xDripAPS, statusCode = ' + response.statusCode);
         }
       })
+    },
+
+    postCalibration: (calData) => {
+
+      const entry = [{
+        'device': 'openaps://' + os.hostname(),
+        'type': 'cal',
+        'date': calData.date,
+        'scale': calData.scale,
+        'intercept': calData.intercept,
+        'slope': calData.slope,
+      }];
+
+      const data = JSON.stringify(entry);
+
+      const secret = process.env.API_SECRET;
+      let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/entries.json';
+      let ns_headers = {
+          'Content-Type': 'application/json'
+      };
+
+      if (secret.startsWith("token=")) {
+        ns_url = ns_url + '?' + secret;
+      } else {
+        ns_headers['API-SECRET'] = secret;
+      }
+
+      const optionsNS = {
+          url: ns_url,
+          method: 'POST',
+          headers: ns_headers,
+          body: entry,
+          json: true
+      };
+
+      request(optionsNS, function (error, response, body) {
+        if (error) {
+          console.error('error posting json: ', error)
+        } else {
+          console.log('uploaded new calibration to NS, statusCode = ' + response.statusCode);
+        }
+      })
     }
   };
 };

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -29,6 +29,8 @@ module.exports = () => {
         direction = 'DoubleUp';
       }
 
+      console.log('Trend: ' + glucose.trend + ' direction: ' + direction);
+
       const entry = [{
         'device': 'openaps://' + os.hostname(),
         'date': glucose.readDate,


### PR DESCRIPTION
This update calculates a linear calibration curve from the unfiltered and G5 calibrated values.

If extend_sensor option is enabled on the command line, it will use this calibration to continue reporting calibrated glucose values after the G5 stops reporting due to the 7 day sensor life or any other reason.

This update also calculates the noise and trend values using the algorithm provided in xdrip-js-logger by @efidoman. The intent is to maintain safety while looping by detecting noise and correctly tagging it so OpenAPS will respond appropriately when sensor noise is detected.